### PR TITLE
Upgrade h11 to >=0.16 to avoid security vulnerability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "anyio>=3.5.0, <5",
     "distro>=1.7.0, <2",
     "sniffio",
+    "h11>=0.16",
 ]
 requires-python = ">= 3.8"
 classifiers = [

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -48,9 +48,10 @@ filelock==3.12.4
 frozenlist==1.6.2
     # via aiohttp
     # via aiosignal
-h11==0.14.0
+h11==0.16.0
     # via httpcore
-httpcore==1.0.2
+    # via runwayml
+httpcore==1.0.9
     # via httpx
 httpx==0.28.1
     # via httpx-aiohttp

--- a/requirements.lock
+++ b/requirements.lock
@@ -36,9 +36,10 @@ exceptiongroup==1.2.2
 frozenlist==1.6.2
     # via aiohttp
     # via aiosignal
-h11==0.14.0
+h11==0.16.0
     # via httpcore
-httpcore==1.0.2
+    # via runwayml
+httpcore==1.0.9
     # via httpx
 httpx==0.28.1
     # via httpx-aiohttp


### PR DESCRIPTION
h11==0.14 is associated with a critical security vulnerability

https://github.com/python-hyper/h11/commit/114803a29ce50116dc47951c690ad4892b1a36ed
https://github.com/python-hyper/h11/security/advisories/GHSA-vqfr-h8mv-ghfj
https://github.com/python-hyper/h11
https://nvd.nist.gov/vuln/detail/CVE-2025-43859
https://access.redhat.com/security/cve/CVE-2025-43859
https://www.cve.org/CVERecord?id=CVE-2025-43859

Would be great to upgrade this package.