### PR TITLE
fix(ci): publish on v* tag if release event is skipped

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,12 +1,19 @@
-# This workflow is triggered when a GitHub release is created.
-# It can also be run manually to re-publish to PyPI in case it failed for some reason.
-# You can run this workflow by navigating to https://www.github.com/runwayml/sdk-python/actions/workflows/publish-pypi.yml
+# Publish when a GitHub release is created, when a v* tag is pushed, or by hand.
+# App-created tags sometimes skip the `release` event (GITHUB_TOKEN / App delivery).
+# `push: tags` is the backup. bin/publish-pypi no-ops if the version is already on PyPI.
+# Manual: https://www.github.com/runwayml/sdk-python/actions/workflows/publish-pypi.yml
 name: Publish PyPI
 on:
   workflow_dispatch:
-
   release:
     types: [published]
+  push:
+    tags:
+      - 'v*'
+
+concurrency:
+  group: publish-pypi-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   publish:

--- a/bin/publish-pypi
+++ b/bin/publish-pypi
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 
 set -eux
+
+VERSION="$(sed -n 's/^version = "\(.*\)"/\1/p' pyproject.toml | head -1)"
+if [ -n "$VERSION" ] && curl -sf "https://pypi.org/pypi/runwayml/${VERSION}/json" >/dev/null; then
+  echo "already published runwayml==$VERSION — skip"
+  exit 0
+fi
+
 mkdir -p dist
 rye build --clean
 rye publish --yes --token=$PYPI_TOKEN


### PR DESCRIPTION
## Summary
- GitHub `release` events from Stainless App sometimes never start Publish PyPI (5.16.1 tag existed; workflow did not run; we dispatched by hand).
- Also run on `push` of `v*` tags. Skip if `runwayml` is already that version on PyPI so tag + release cannot double-fail.

## Test plan
- [ ] Workflow file on `main` after merge (tag/release events read the default branch)
- [ ] Next `v*` tag should start Publish even if `on: release` is silent
- [ ] Re-running publish for an already-published version exits 0